### PR TITLE
Fix Thread XML configuration and fix XML field property

### DIFF
--- a/Resources/config/doctrine/Message.mongodb.xml
+++ b/Resources/config/doctrine/Message.mongodb.xml
@@ -6,13 +6,13 @@
 
     <mapped-superclass name="FOS\MessageBundle\Document\Message" collection="fos_message_message">
 
-        <field name="body" fieldName="body" type="string" />
+        <field name="body" field-name="body" type="string" />
 
-        <field name="createdAt" fieldName="createdAt" type="date" />
+        <field name="createdAt" field-name="createdAt" type="date" />
 
-        <field name="isSpam" fieldName="isSpam" type="boolean" />
+        <field name="isSpam" field-name="isSpam" type="boolean" />
 
-        <field name="unreadForParticipants" fieldName="unreadForParticipants" type="collection" />
+        <field name="unreadForParticipants" field-name="unreadForParticipants" type="collection" />
 
         <!--<embed-many target-document="FOS\MessageBundle\Document\MessageMetadata" field="metadata" />-->
 

--- a/Resources/config/doctrine/MessageMetadata.mongodb.xml
+++ b/Resources/config/doctrine/MessageMetadata.mongodb.xml
@@ -6,7 +6,7 @@
 
     <mapped-superclass name="FOS\MessageBundle\Document\MessageMetadata">
 
-        <field name="isRead" fieldName="isRead" type="boolean" />
+        <field name="isRead" field-name="isRead" type="boolean" />
 
         <!--<reference-one field="participant" target-document="Acme\UserBundle\Document\User" />-->
 

--- a/Resources/config/doctrine/Thread.mongodb.xml
+++ b/Resources/config/doctrine/Thread.mongodb.xml
@@ -6,7 +6,7 @@
 
     <mapped-superclass name="FOS\MessageBundle\Document\Thread" collection="fos_message_thread">
 
-        <field name="subject" fieldName="subject" type="string" />
+        <field name="subject" field-name="subject" type="string" />
 
         <!--<embed-many target-document="FOS\MessageBundle\Document\ThreadMetadata" field="metadata" />-->
 
@@ -16,19 +16,19 @@
 
         <!--<reference-one field="createdBy" target-document="Acme\UserBundle\Document\User" />-->
 
-        <field name="createdAt" fieldName="createdAt" type="date" />
+        <field name="createdAt" field-name="createdAt" type="date" />
 
-        <field name="lastMessageDate" fieldName="lastMessageDate" type="date" />
+        <field name="lastMessageDate" field-name="lastMessageDate" type="date" />
 
-        <field name="isSpam" fieldName="isSpam" type="boolean" />
+        <field name="isSpam" field-name="isSpam" type="boolean" />
 
-        <field name="keywords" fieldName="keywords" type="string" />
+        <field name="keywords" field-name="keywords" type="string" />
 
-        <field name="activeParticipants" fieldName="activeParticipants" type="collection" />
+        <field name="activeParticipants" field-name="activeParticipants" type="collection" />
 
-        <field name="activeRecipients" fieldName="activeRecipients" type="collection" />
+        <field name="activeRecipients" field-name="activeRecipients" type="collection" />
 
-        <field name="activeSenders" fieldName="activeSenders" type="collection" />
+        <field name="activeSenders" field-name="activeSenders" type="collection" />
 
         <indexes>
             <index>

--- a/Resources/config/doctrine/ThreadMetadata.mongodb.xml
+++ b/Resources/config/doctrine/ThreadMetadata.mongodb.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
-                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\MessageBundle\Document\ThreadMetadata">
 
-        <field name="isDeleted" column="isDeleted" type="boolean" />
+        <field name="isDeleted" field-name="isDeleted" type="boolean" />
 
-        <field name="lastParticipantMessageDate" column="lastParticipantMessageDate" type="date" />
+        <field name="lastParticipantMessageDate" field-name="lastParticipantMessageDate" type="date" />
 
-        <field name="lastMessageDate" column="lastMessageDate" type="date" />
+        <field name="lastMessageDate" field-name="lastMessageDate" type="date" />
 
         <!--<reference-one field="participant" target-document="Acme\UserBundle\Document\User" />-->
 
     </mapped-superclass>
 
-</doctrine-mapping>
+</doctrine-mongo-mapping>


### PR DESCRIPTION
According to MongoDB ODM 2.x, fieldName attribute has been renamed to field-name. This has been fixed.
The File ThreadMetadata.mongodb.xml had an incorrect mapping. This has been fixed.